### PR TITLE
Update repo_sync.yml

### DIFF
--- a/.github/workflows/repo_sync.yml
+++ b/.github/workflows/repo_sync.yml
@@ -8,13 +8,17 @@ on:
 
 jobs:
   repo-sync:
+    env:
+      PAT: ${{ secrets.PAT }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      if: env.PAT
       with:
         persist-credentials: false
     - name: repo-sync
       uses: repo-sync/github-sync@v2
+      if: env.PAT
       with:
         source_repo: "https://github.com/lxk0301/scripts.git"
         source_branch: "master"


### PR DESCRIPTION
repo-async: fixed secrets.PAT error with checking it's exist

**解决未添加 secrets.PAT 时的报错：**

增加条件判断 secrets.PAT，

- 若没有设置 PAT，则跳过 sync 同步功能，即 Action 执行完毕（成功）；

- 若已设置 PAT，则执行 sync 同步功能。